### PR TITLE
fix link to git-diff in index.html

### DIFF
--- a/Git.docset/Contents/Resources/Documents/index.html
+++ b/Git.docset/Contents/Resources/Documents/index.html
@@ -26,7 +26,7 @@
 <ul class="unstyled">
 <li><a href="docs/git-add.html">add</a></li>
 <li><a href="docs/git-status.html">status</a></li>
-<li><a href="docs/git-diff">diff</a></li>
+<li><a href="docs/git-diff.html">diff</a></li>
 <li><a href="docs/git-commit.html">commit</a></li>
 <li><a href="docs/git-reset.html">reset</a></li>
 <li><a href="docs/git-rm.html">rm</a></li>


### PR DESCRIPTION
somehow the '.html' extension was missing for just the git-diff